### PR TITLE
infer data type from type hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,54 @@ Install from [PyPi](https://pypi.org/project/badger-config-handler/)
 pip install badger-config-handler
 ```
 
-# Data types
+# Rules and limitations
+
+1. settings are declared in the class and defined in [setup()](#setup-1)
+2. settings **MUST** be declared with a type hint.  example: `my_var: int`
+3. settings can only be of [allowed data type](allowed-data-types)
+4. settings not declared in code are ignored in the config file (and are removed on the next save, same for commented out settings)
+5. settings can be `None` if they are set to null in the config, regardles of the type hint
+6. settings without a default value set in [setup()](#setup-1) are not saved to the config file, but they can still be set from the config file
+
+
+
+# Example config
+
+``` Python
+class Sub_Section(Badger_Config_Section):
+    section_var: str
+    section_int: int
+
+    def setup(self):
+        self.section_var = "section"
+        self.section_int = 20
+
+class base(Badger_Config_Base):
+    my_var: str
+    my_int: int
+    my_none: str
+    
+    sub_section: Sub_Section # NOT Badger_Config_Section
+
+    def setup(self):
+        self.my_var = "test"
+        self.my_int = 50
+        self.my_none = None
+        
+        self.sub_section = Sub_Section(section_name="sub")
+
+config = My_Base(
+    config_file_path="path/to/config.json",
+    root_path="path/to/project/root"
+)
+
+config.save()
+config.load()
+config.sync()
+```
+
+
+# Allowed data types
 
 ## native
 the file handlers have native support for these types and are used as is,

--- a/src/badger_config_handler/badger_config_handler.py
+++ b/src/badger_config_handler/badger_config_handler.py
@@ -444,13 +444,42 @@ class Badger_Config_Section(ABC):
             # print(f"Key: {s_name}, value: {s_value}")
             # a TODO check dict keys as well (make it optional)
 
-            if not safe_load or hasattr(self, s_name):
+            # if not safe_load or hasattr(self, s_name):
+            if hasattr(self, s_name):
                 if DEBUG_from_dict:
                     print()
-                    print(f"Key: {s_name}, value: {s_value}")
+                    print("+"*50)
+                    print(f"Key: {s_name} \tvalue: {s_value}")
 
-                class_var = getattr(self, s_name, None)
-                target_type = type(class_var) if s_value is not None else None
+                    print()
+                    print("Annotations start")
+                    print("all: ", self.__annotations__)
+
+                target_type = self.__annotations__.get(
+                    s_name, BADGER_NONE)
+
+                print()
+
+                if target_type is BADGER_NONE:
+                    raise TypeError(
+                        f"No type hinting set for setting: {s_name}")
+
+                if s_value is not None:
+                    # create instance and then get the type
+                    # is needed in cases where lists or dicts have content annotated
+                    # like this: my_var: list[int]
+                    # turn annotation into class
+                    target_type = type(target_type())
+
+                else:
+                    target_type = None
+
+                if DEBUG_from_dict:
+                    # print("post: var:", add_padding(target_type, 20),
+                    #     "type:", type(target_type))
+
+                    print("target type: ", target_type)
+                    print()
 
                 s_value = self._native_to_var(
                     var_native=s_value,
@@ -632,6 +661,7 @@ class Badger_Config_Section(ABC):
             Either `var` of `type` must be set
         """
         native_types = (str, int, float, bool)  # and None
+
         if var is not BADGER_NONE:
             # if var is None:
             #     return True

--- a/tests/base_test_setup.py
+++ b/tests/base_test_setup.py
@@ -44,13 +44,16 @@ class Base_Test():
             my_var: str
             my_int: int
             my_none: str
+            
+            sub_section: Sub_Section
 
             def setup(self):
                 self.my_var = "test"
                 self.my_int = 50
                 self.my_none = None
+                
+                self.sub_section = Sub_Section(section_name="sub")
 
-            sub_section = Sub_Section(section_name="sub")
 
         if config_file_path is None:
             config_file_path = self.TEST_CONFIG_PATH
@@ -118,8 +121,8 @@ class Base_Test():
 
         mid_conf = self.get_config_dict(conf)
 
-        conf.load()
         conf = self.get_test_config()
+        conf.load()
 
         end_conf = self.get_config_dict(conf)
 

--- a/tests/test_json_config.py
+++ b/tests/test_json_config.py
@@ -5,6 +5,8 @@ from base_test_setup import Base_Test
 TEST_CONFIG_NAME = "config.json"
 
 # test save to file
+
+
 def test_save_config():
     Base_Test(TEST_CONFIG_NAME).test_save_config()
 
@@ -20,6 +22,13 @@ def test_compare_config():
     Base_Test(TEST_CONFIG_NAME).test_compare_config()
 
 
+def test_null_default_handled_right():
+    Base_Test(TEST_CONFIG_NAME).test_null_default_handled_right()
+
 # test sync
 
 # ? test unsupported data type ?
+
+
+if __name__ == "__main__":
+    test_null_default_handled_right()

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -37,6 +37,14 @@ def test_load_config():
 def test_compare_config():
     Base_Test(TEST_CONFIG_NAME).test_compare_config()
 
+
+def test_null_default_handled_right():
+    Base_Test(TEST_CONFIG_NAME).test_null_default_handled_right()
+
 # test sync
 
 # ? test unsupported data type ?
+
+
+if __name__ == "__main__":
+    test_null_default_handled_right()


### PR DESCRIPTION
Data types are noww infered from the type hint, using `__annotations__`.

This fixes the problem that values set to default `None` can't be overwritten from the config file.