### PR TITLE
Fix/auto save on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,31 @@ steps:
 
 Load config from file
 
+**Parameters:**
+
+| param                       | type | required     | default | Note                            |
+|-----------------------------|------|--------------|---------|---------------------------------|
+| auto_create                 | bool |              | True    | Create config file if not found |
+| safe_load [see](#from_dict) | bool |              | True    |  ! UNTESTED !                   |
+
 ---
 
 #### sync()
 
 Sync config with file
 
-runs: `load()` - `save()` - `load()`
+runs:
+
+1. `load()`
+    - if file exists then continue else stop here
+2. `save()`
+3. `load()`
 
 this adds new config fields to the file or removes old ones
+
+**Parameters:**
+
+same as [load()](#load)
 
 ---
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 description = "Config handler for code-declared and file-defined settings."
 readme = "README.md"
 requires-python = ">=3.7"
-# license = {file = "LICENSE"}
+license = {file = "LICENSE"}
 keywords = ["settings handler", "config handler", "json", "yaml"]
 authors = [
   {name = "pidi3000"},

--- a/src/badger_config_handler/badger_config_handler.py
+++ b/src/badger_config_handler/badger_config_handler.py
@@ -1022,7 +1022,7 @@ class Badger_Config_Base(Badger_Config_Section):
     ##################################################
     # File loading
     ##################################################
-    def load(self, safe_load: bool = True, auto_craete: bool = True) -> bool:
+    def load(self, safe_load: bool = True, auto_create: bool = True) -> bool:
         """Load settings from file
 
         Overrides the default values with the one set in file, \n
@@ -1040,20 +1040,20 @@ class Badger_Config_Base(Badger_Config_Section):
             True -> Only variables that already exist in the class are set (uses `hasattr`)\n
             False -> New variables can be set from config file
 
-        auto_craete : bool, optional
+        auto_create : bool, optional
             by default True\n
             if config file not found auto create it
 
         Returns
         -------
         bool
-            if auto_craete -> True, a new config file was created
+            if auto_create -> True, a new config file was created
 
 
         Raises
         ------
         FileNotFoundError
-            if auto_craete -> False and config file was not found 
+            if auto_create -> False and config file was not found 
 
         """
         if DEBUG_load:
@@ -1061,7 +1061,7 @@ class Badger_Config_Base(Badger_Config_Section):
             print("DEBUG START LOAD")
             print("-"*50)
 
-        data, created_new = self._load_from_file(auto_craete=auto_craete)
+        data, created_new = self._load_from_file(auto_create=auto_create)
         self.from_dict(data=data, safe_load=safe_load)
 
         # try:
@@ -1087,12 +1087,12 @@ class Badger_Config_Base(Badger_Config_Section):
 
         return created_new
 
-    def _load_from_file(self, attempt_count=0, auto_craete: bool = True):
+    def _load_from_file(self, attempt_count=0, auto_create: bool = True):
         """Load raw data from config file
 
         Parameters
         ----------            
-        auto_craete : bool, optional
+        auto_create : bool, optional
             by default True\n
             if config file not found auto create it
         """
@@ -1104,7 +1104,7 @@ class Badger_Config_Base(Badger_Config_Section):
         created_new = False
 
         if not self._config_file_path.exists():
-            if auto_craete:
+            if auto_create:
                 self.save()
                 created_new = True
             else:
@@ -1144,7 +1144,7 @@ class Badger_Config_Base(Badger_Config_Section):
 
         return data, created_new
 
-    def sync(self, safe_load: bool = True, auto_craete: bool = True):
+    def sync(self, safe_load: bool = True, auto_create: bool = True):
         """Add new variables to existing config file
 
         Same as running `load()` then `safe()` then `load()`\n
@@ -1154,21 +1154,21 @@ class Badger_Config_Base(Badger_Config_Section):
         safe_load : bool, optional
             see `load()` for more details, by default True
 
-        auto_craete : bool, optional
+        auto_create : bool, optional
             by default True\n
             if config file not found auto create it
 
         Returns
         -------
         bool
-            if auto_craete -> True, a new config file was created
+            if auto_create -> True, a new config file was created
 
         Raises
         ------
         FileNotFoundError
-            if auto_craete -> False and config file was not found 
+            if auto_create -> False and config file was not found 
         """
-        created_new = self.load(safe_load=safe_load, auto_craete=auto_craete)
+        created_new = self.load(safe_load=safe_load, auto_create=auto_create)
 
         if not created_new:
             self.save()

--- a/src/badger_config_handler/badger_config_handler.py
+++ b/src/badger_config_handler/badger_config_handler.py
@@ -825,7 +825,7 @@ class Badger_Config_Section(_Config_data_handler):
     ##################################################
     def _is_relative_to(self, absolute_path: Path, base_path: Path):
         """back port of pathlib.Path.is_relative_to
-        
+
         was introduce in python v 3.9
         """
 
@@ -1022,11 +1022,7 @@ class Badger_Config_Base(Badger_Config_Section):
     ##################################################
     # File loading
     ##################################################
-    def load(self, safe_load: bool = True):
-        """Save config to file
-
-        Pre process's all sub sections and write the values to file
-        """
+    def load(self, safe_load: bool = True, auto_craete: bool = True) -> bool:
         """Load settings from file
 
         Overrides the default values with the one set in file, \n
@@ -1035,16 +1031,37 @@ class Badger_Config_Base(Badger_Config_Section):
         Parameters
         ----------
         safe_load
+
+        Parameters
+        ----------
+        safe_load : bool, optional
+            by default True\n
             # ! UNTESTED ! \n
             True -> Only variables that already exist in the class are set (uses `hasattr`)\n
             False -> New variables can be set from config file
+
+        auto_craete : bool, optional
+            by default True\n
+            if config file not found auto create it
+
+        Returns
+        -------
+        bool
+            if auto_craete -> True, a new config file was created
+
+
+        Raises
+        ------
+        FileNotFoundError
+            if auto_craete -> False and config file was not found 
+
         """
         if DEBUG_load:
             print("-"*50)
             print("DEBUG START LOAD")
             print("-"*50)
 
-        data = self._load_from_file()
+        data, created_new = self._load_from_file(auto_craete=auto_craete)
         self.from_dict(data=data, safe_load=safe_load)
 
         # try:
@@ -1068,16 +1085,31 @@ class Badger_Config_Base(Badger_Config_Section):
             print("DEBUG END LOAD")
             print("-"*50)
 
-    def _load_from_file(self, attempt_count=0):
+        return created_new
+
+    def _load_from_file(self, attempt_count=0, auto_craete: bool = True):
         """Load raw data from config file
+
+        Parameters
+        ----------            
+        auto_craete : bool, optional
+            by default True\n
+            if config file not found auto create it
         """
         if DEBUG__load_from_file:
             print("-"*50)
             print("DEBUG START LOAD FROM FILE")
             print("-"*50)
 
+        created_new = False
+
         if not self._config_file_path.exists():
-            self.save()
+            if auto_craete:
+                self.save()
+                created_new = True
+            else:
+                raise FileNotFoundError(
+                    f"The config file was not found: {self._config_file_path}")
 
         with open(self._config_file_path, "r") as f:
             if self._config_file_type in ["yaml", "yml"]:
@@ -1110,9 +1142,9 @@ class Badger_Config_Base(Badger_Config_Section):
             print("DEBUG END LOAD FROM FILE")
             print("-"*50)
 
-        return data
+        return data, created_new
 
-    def sync(self, safe_load: bool = True):
+    def sync(self, safe_load: bool = True, auto_craete: bool = True):
         """Add new variables to existing config file
 
         Same as running `load()` then `safe()` then `load()`\n
@@ -1121,7 +1153,25 @@ class Badger_Config_Base(Badger_Config_Section):
         ----------
         safe_load : bool, optional
             see `load()` for more details, by default True
+
+        auto_craete : bool, optional
+            by default True\n
+            if config file not found auto create it
+
+        Returns
+        -------
+        bool
+            if auto_craete -> True, a new config file was created
+
+        Raises
+        ------
+        FileNotFoundError
+            if auto_craete -> False and config file was not found 
         """
-        self.load(safe_load=safe_load)
-        self.save()
-        self.load(safe_load=safe_load)
+        created_new = self.load(safe_load=safe_load, auto_craete=auto_craete)
+
+        if not created_new:
+            self.save()
+            self.load(safe_load=safe_load)
+            
+        return created_new

--- a/tests/base_test_setup.py
+++ b/tests/base_test_setup.py
@@ -18,25 +18,25 @@ class Base_Test():
     @pytest.mark.dependency(name="dependecies_present")
     def test_dependecies_present(self):
         assert self.ensure_dependencies_present()
-        
+
     def ensure_dependencies_present(self):
         """base test to ensure all dependecies are present
-        
+
         overwrite in sub class if needed
-        
+
         Return
         ------
         bool:
             all dependencies present
         tuple[bool, str]:
             optional tuple with str for error messages
-            
+
         """
         return True
 
     def get_test_config_path(self):
         return self.TEST_DATA_DIR.joinpath(self.config_file_name)
-    
+
     def setup_data_dir(self, remove_config_file=True):
         self.TEST_DATA_DIR.mkdir(exist_ok=True)
 
@@ -94,15 +94,15 @@ class Base_Test():
 
     ####################################################################################################
 
-    @pytest.mark.dependency(depends=["dependecies_present"])
+    @pytest.mark.dependency(name="save_config", depends=["dependecies_present"])
     def test_save_config(self, ):
         self.setup_data_dir()
         conf = self.get_test_config()
         conf.save()
 
-    ##################################################
+    ####################################################################################################
     # test load from file
-    ##################################################
+    ####################################################################################################
 
     @pytest.mark.dependency(depends=["dependecies_present"])
     def test_load_config(self, ):
@@ -114,6 +114,7 @@ class Base_Test():
     # compare loaded data to original
     ##################################################
 
+    # TODO check
     @pytest.mark.dependency(depends=["dependecies_present"])
     def test_compare_config(self, ):
         self.setup_data_dir()
@@ -126,9 +127,54 @@ class Base_Test():
 
         assert start_conf == end_conf
 
+    ####################################################################################################
+    # test sync
+    ####################################################################################################
+
+    class Test_Sync:
+        pass
+
     ##################################################
+    # test cases where no config file was found
+    ##################################################
+    @pytest.mark.dependency(depends=["dependecies_present"])
+    def test_sync_no_file_create(self):
+        print(self.config_file_name)
+
+        self.setup_data_dir(remove_config_file=True)
+        conf = self.get_test_config()
+
+        assert conf.sync() == True
+
+    @pytest.mark.dependency(depends=["dependecies_present"])
+    def test_sync_no_file_error(self):
+        print(self.config_file_name)
+
+        self.setup_data_dir(remove_config_file=True)
+        conf = self.get_test_config()
+
+        with pytest.raises(FileNotFoundError) as e_info:
+            conf.sync(auto_craete=False)
+
+    ##################################################
+    # test cases where config file exists
+    ##################################################
+    @pytest.mark.dependency(depends=["dependecies_present", "save_config"])
+    def test_sync_file_exist(self):
+        self.setup_data_dir(remove_config_file=True)
+        
+        # Create a config file
+        conf = self.get_test_config()
+        conf.save()
+        
+        ##############################
+        conf = self.get_test_config()
+
+        assert conf.sync() == False
+
+    ####################################################################################################
     # test default None values overwrite
-    ##################################################
+    ####################################################################################################
 
     @pytest.mark.dependency(depends=["dependecies_present"])
     def test_null_default_handled_right(self):

--- a/tests/base_test_setup.py
+++ b/tests/base_test_setup.py
@@ -151,7 +151,7 @@ class Base_Test():
         conf = self.get_test_config()
 
         with pytest.raises(FileNotFoundError) as e_info:
-            conf.sync(auto_craete=False)
+            conf.sync(auto_create=False)
 
     ##################################################
     # test cases where config file exists

--- a/tests/base_test_setup.py
+++ b/tests/base_test_setup.py
@@ -131,9 +131,6 @@ class Base_Test():
     # test sync
     ####################################################################################################
 
-    class Test_Sync:
-        pass
-
     ##################################################
     # test cases where no config file was found
     ##################################################
@@ -162,11 +159,11 @@ class Base_Test():
     @pytest.mark.dependency(depends=["dependecies_present", "save_config"])
     def test_sync_file_exist(self):
         self.setup_data_dir(remove_config_file=True)
-        
+
         # Create a config file
         conf = self.get_test_config()
         conf.save()
-        
+
         ##############################
         conf = self.get_test_config()
 
@@ -271,7 +268,5 @@ class Base_Test():
         assert mid_path != end_path
         assert start_path == end_path
         assert mid_path2 == end_path
-
-    # test sync
 
     # ? test unsupported data type ?


### PR DESCRIPTION
When running `load()` and the config file was not found it was always auto created,
now it's configurable using the `auto_create` parameter. Also a boolean is returned to indicate id a new file was created.

This is used to optimize `sync()`, stopping after the first `load()` if a new file was created

Added tests for sync:
- when no config file exists
- with existing config file

README was updated with these changes
